### PR TITLE
Fix accumulation of time duration in subsequent events

### DIFF
--- a/src/green/utils/timing.h
+++ b/src/green/utils/timing.h
@@ -38,7 +38,7 @@ namespace green::utils {
 
   struct event_t {
     event_t() : start(0), duration(0), active(false), accumulate(true) {}
-    event_t(double start_, double duration_) : start(start_), duration(duration_), active(false){};
+    event_t(double start_, double duration_, bool accumulate_) : start(start_), duration(duration_), active(false), accumulate(accumulate_){};
     double                                                    start;
     double                                                    duration;
     bool                                                      active;

--- a/src/green/utils/timing.h
+++ b/src/green/utils/timing.h
@@ -205,7 +205,8 @@ namespace green::utils {
 
     /**
      * @brief reset the `duration` attribute of all child events of the current event
-     * 
+     * If there is no current event (i.e., at the root level when `_current_event` is nullptr),
+     * this method returns silently and does nothing.
      */
     void reset() {
       if (!_current_event) return;

--- a/src/green/utils/timing.h
+++ b/src/green/utils/timing.h
@@ -38,6 +38,7 @@ namespace green::utils {
 
   struct event_t {
     event_t() : start(0), duration(0), active(false), accumulate(true) {}
+    event_t(double start_, double duration_) : start(start_), duration(duration_), active(false), accumulate(true){};
     event_t(double start_, double duration_, bool accumulate_) : start(start_), duration(duration_), active(false), accumulate(accumulate_){};
     double                                                    start;
     double                                                    duration;

--- a/src/green/utils/timing.h
+++ b/src/green/utils/timing.h
@@ -158,7 +158,7 @@ namespace green::utils {
      * @param name - event name to start time measurement
      * @param accumulate - whether to accumulate time for this event
      */
-    void start(const std::string& name, bool accumulate=false) {
+    void start(const std::string& name, bool accumulate=true) {
 #ifndef NDEBUG
       if (_root_events.find(name) != _root_events.end() && _root_events[name]->active) {
         throw wrong_event_state("Event is already active");

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("Timing") {
     statistic.end();
     double e2 = MPI_Wtime();
     double duration2 = statistic.event("ACCUMULATE ON").duration;
-    REQUIRE(std::abs(duration2 - (e2 + e1 - s1 - s2)) < 1e-2);
+    REQUIRE(std::abs(duration2 - ((e2 - s2) + (e1 - s1))) < 1e-2);
 
     // Test case when Accumulate is OFF
     statistic.start("ACCUMULATE OFF", false);

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -144,5 +144,5 @@ TEST_CASE("Timing") {
 
     REQUIRE(duration_child1 == 0.0);
     REQUIRE(duration_child2 == 0.0);
-  } 
+  }
 }

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -93,4 +93,56 @@ TEST_CASE("Timing") {
     REQUIRE(statistic.event("UNKNOWN2").parent == &statistic.event("TEST"));
     statistic.end();
   }
+
+  SECTION("Test Accumulate") {
+    // Test case when Accumulate is ON
+    green::utils::timing statistic;
+    double s1 = MPI_Wtime();
+    statistic.start("ACCUMULATE ON", true);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    statistic.end();
+    double e1 = MPI_Wtime();
+    double duration1 = statistic.event("ACCUMULATE ON").duration;
+    REQUIRE(std::abs(duration1 - (e1 - s1)) < 1e-2);
+
+    double s2 = MPI_Wtime();
+    statistic.start("ACCUMULATE ON", true);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    statistic.end();
+    double e2 = MPI_Wtime();
+    double duration2 = statistic.event("ACCUMULATE ON").duration;
+    REQUIRE(std::abs(duration2 - (e2 + e1 - s1 - s2)) < 1e-2);
+
+    // Test case when Accumulate is OFF
+    statistic.start("ACCUMULATE OFF", false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    statistic.end();
+    double duration3 = statistic.event("ACCUMULATE OFF").duration;
+
+    statistic.start("ACCUMULATE OFF", false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    statistic.end();
+    double duration4 = statistic.event("ACCUMULATE OFF").duration;
+    REQUIRE(std::abs(duration4 - duration3) < 1e-2);
+  }
+
+  SECTION("Test Reset") {
+    green::utils::timing statistic;
+    statistic.start("ROOT");
+    statistic.start("CHILD1");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    statistic.end();
+    statistic.start("CHILD2");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    statistic.end();
+    statistic.reset();
+    statistic.end();
+
+    double duration_root = statistic.event("ROOT").duration;
+    double duration_child1 = statistic.event("ROOT").children["CHILD1"]->duration;
+    double duration_child2 = statistic.event("ROOT").children["CHILD2"]->duration;
+
+    REQUIRE(duration_child1 == 0.0);
+    REQUIRE(duration_child2 == 0.0);
+  } 
 }


### PR DESCRIPTION
In the current default behavior of timing module, repeated calls of `start` and `stop` for same event accumulates the duration of the event. While, in general, this is good within a SCF iteration, transfer of the accumulated `duration` across multiple iterations is problematic.

This PR fixes this issue by adding a boolean keyword `accumulate` in the declaration of `event`.
Tests are also added for the new functionality.